### PR TITLE
Correct recommended fastcgi location regex in Drupal recipe

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -64,7 +64,15 @@ Recipe
             rewrite ^/(.*)$ /index.php?q=$1;
         }
 
-        location ~ \.php(/|$) {
+        # In Drupal 8, we must also match new paths where the '.php' appears in the middle,
+        # such as update.php/selection. The rule we use is strict, and only allows this pattern
+        # with the update.php front controller.  This allows legacy path aliases in the form of
+        # blog/index.php/legacy-path to continue to route to Drupal nodes. If you do not have 
+        # any paths like that, then you might prefer to use a laxer rule, such as: 
+        #   location ~ \.php(/|$) {
+        # The laxer rule will continue to work if Drupal uses this new URL pattern with front
+        # controllers other than update.php in a future release.
+        location ~ '\.php$|^/update.php' {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
             include fastcgi_params;


### PR DESCRIPTION
The fastcgi `location` directive I recommended in #207 matched the new Drupal 8 URL style, `update.php/selection` & c., with a very lax rule, so that future paths of this nature that Drupal 8 might add in the future would also work.  However, this lax regex got in the way of folks with legacy path aliases such as `blog/index.php/legacy-path`, e.g. in instances where they migrated a site from some old CMS that did not use clean URLs, and needed to continue to serve the legacy locations after migration.

This PR therefore recommends a stricter pattern, as suggested by https://insready.com/en/blog/update-your-nginx-config-support-drupal-8, so these sorts of paths will continue to work for those who need them.

Since this situation is somewhat complex, and there isn't really one single solution that is likely to be right for all users for all time (if we include the possibility of future Drupal 8 changes), I have included a fairly long explanatory comment. This could be pruned down, if desired, as the new location should by an acceptable solution for all users for right now.
